### PR TITLE
fix: correct JK charge and discharge energy direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ description:
 # Changelog
 
 
+## 1.9.87
+
+-   [JKBMS] Fix signed power direction so discharge energy is accumulated separately from charged energy.
+
+---------------
+
+
 ## 1.9.86
 
 -   [JKBMS] Fix setup frame voltage register parsing for `VolInverterMaxCharge` (Inverter Max Charge Voltage) at offset 38 and `VolFloatCharge` (Float Charge Voltage) at offset 42 (previously misidentified as battery undervoltage/overvoltage protection).

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name: "Gobel Battery Monitor"
 description: "Battery Monitor supports various BMS - Home Assistant Addon"
-version: "1.9.86"
+version: "1.9.87"
 slug: "gobel_battery_monitor"
 url: "https://github.com/fancyui/Gobel-Battery-HA-Addon"
 init: false

--- a/jkbms_rs485.py
+++ b/jkbms_rs485.py
@@ -341,6 +341,8 @@ class JKBMS485:
         if 162 <= len(data):
             raw_c = struct.unpack_from('<i', data, 158)[0]
             result['current_a'] = raw_c / 1000.0  # mA → A
+            if 'power_kw' in result and raw_c < 0:
+                result['power_kw'] = -result['power_kw']
 
         # ---- Battery temp sensors: int16le at 162, 164, 254, 256, 258 (/10 = °C) ----
         temps = {

--- a/test_jkbms_energy.py
+++ b/test_jkbms_energy.py
@@ -1,0 +1,46 @@
+import logging
+import struct
+import unittest
+from unittest.mock import patch
+
+from jkbms_rs485 import JKBMS485
+
+
+class JKBMSEnergyTest(unittest.TestCase):
+    def setUp(self):
+        self.bms = JKBMS485.__new__(JKBMS485)
+        self.bms.logger = logging.getLogger(__name__)
+        self.bms.pack_energy = {}
+
+    def parse_power(self, power_mw, current_ma):
+        frame = bytearray(300)
+        frame[0:2] = b"\x55\xaa"
+        struct.pack_into("<I", frame, 154, power_mw)
+        struct.pack_into("<i", frame, 158, current_ma)
+        return self.bms.parse_jkbms_55aa_frame(frame)["power_kw"]
+
+    def test_positive_current_produces_positive_power(self):
+        self.assertEqual(self.parse_power(1_500_000, 30_000), 1.5)
+
+    def test_negative_current_produces_negative_power(self):
+        self.assertEqual(self.parse_power(1_500_000, -30_000), -1.5)
+
+    def test_positive_power_accumulates_charged_energy(self):
+        with patch("time.time", side_effect=[100.0, 160.0]):
+            self.bms.calculate_cumulative_energy(0, 1.0)
+            charged, discharged = self.bms.calculate_cumulative_energy(0, 1.0)
+
+        self.assertAlmostEqual(charged, 1000 / 60)
+        self.assertEqual(discharged, 0.0)
+
+    def test_negative_power_accumulates_discharged_energy(self):
+        with patch("time.time", side_effect=[100.0, 160.0]):
+            self.bms.calculate_cumulative_energy(0, -1.0)
+            charged, discharged = self.bms.calculate_cumulative_energy(0, -1.0)
+
+        self.assertEqual(charged, 0.0)
+        self.assertAlmostEqual(discharged, 1000 / 60)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- apply the signed JK current direction to the unsigned power magnitude
- route positive power to charged energy and negative power to discharged energy
- add regression coverage for power sign parsing and cumulative energy routing
- bump the add-on version to 1.9.87 and update the changelog

## Testing
- `python3 -m unittest -v test_jkbms_energy.py`
- `python3 -m py_compile jkbms_rs485.py test_jkbms_energy.py`
- `python3 jk_test_dynamic_parse.py`

Fixes #82